### PR TITLE
Fix a typo in Rubin's rule when computing degree of freedom

### DIFF
--- a/Rmd/02-multiple-imputation.Rmd
+++ b/Rmd/02-multiple-imputation.Rmd
@@ -1020,7 +1020,7 @@ the data is missing. The “old” formula [@RUBIN1987 eq. 3.1.6] for the
 degrees of freedom can be written concisely as
 
 \begin{align}
-  \nu_\mathrm{old} &= (m-1)\left(1+\frac{1}{r^2}\right)  \nonumber\\
+  \nu_\mathrm{old} &= (m-1)\left(1+\frac{1}{r}\right)^2  \nonumber\\
   &= \frac{m-1}{\lambda^2} (\#eq:oldnu) \\
 \end{align}
 


### PR DESCRIPTION
Update 02-multiple-imputation.Rmd

The square is outside the parenthese in eq 3.1.6 of Rubin 1987. 
This commit fixes the typo in the manuscript.

Might check how `mice` is implemented Rubin's rule? But I suppose this is only a typo.